### PR TITLE
Update README with deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,61 @@
-# Run and deploy your AI Studio app
+# 課題解決DXカードゲーム
 
-This contains everything you need to run your app locally.
+## 概要
+「課題解決DXカードゲーム」は、DX用語カードを駆使してビジネス上の課題解決を目指すWebアプリです。各カードには効果とコストが設定されており、選択したカードを基にGemini APIが状況を評価します。戦略的にカードを使いながら、より良い解決策を導き出してください。
 
-## Run Locally
+## 必要環境
+- Node.js (推奨バージョン18以上)
 
-**Prerequisites:**  Node.js
+## セットアップ
+1. 依存パッケージのインストール
+   ```bash
+   npm install
+   ```
+2. Gemini APIキーの設定
+   プロジェクトルートに`.env.local`を作成し、次の内容を記述します。
+   ```env
+   GEMINI_API_KEY=あなたのAPIキー
+   ```
+3. 開発サーバーの起動
+   ```bash
+   npm run dev
+   ```
+   起動後、ブラウザで`http://localhost:5173`(デフォルト)にアクセスしてください。
 
+## ビルド
+本番用ビルドは以下で実行できます。
+```bash
+npm run build
+```
+ビルド結果は`dist`ディレクトリに出力され、`npm run preview`で確認できます。
 
-1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+## ファイル構成
+- `App.tsx` – ゲーム全体のロジック
+- `components/` – 各種Reactコンポーネント
+- `constants.ts` – カード・テーマなどの定義
+- `services/geminiService.ts` – Gemini APIとの通信処理
+
+カードセットやテーマを追加・編集することで、独自のゲームルールを作成することも可能です。
+
+## AWS App Runnerでのデプロイ例
+
+このアプリをAWS App Runnerで動かす場合、以下のようなDockerfileを用意してビルドします。
+
+```Dockerfile
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+ENV HOSTNAME=0.0.0.0
+CMD ["npm", "run", "preview"]
+```
+
+ビルド後、App Runnerのサービス設定で上記コンテナイメージを指定し、`HOSTNAME` 環境変数を`0.0.0.0`に設定してください。これによりヘルスチェックが通りやすくなります。
+
+### ローカルでのDocker動作確認
+```bash
+docker build -t dx-card-game .
+docker run -p 3000:3000 dx-card-game
+```


### PR DESCRIPTION
## Summary
- document how to deploy the Vite app to AWS App Runner using Docker
- keep instructions in Japanese for local usage

## Testing
- `npm run build` *(fails: vite not found)*