### PR TITLE
Add Cloud Run deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      REGION: ${{ secrets.GCP_REGION }}
+      REPOSITORY: ${{ secrets.GAR_REPOSITORY }}
+      SERVICE_NAME: dx-card-game
+      IMAGE_NAME: dx-card-game
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Build and push container
+        run: |
+          gcloud builds submit --tag $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE_NAME:$GITHUB_SHA .
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy $SERVICE_NAME \
+            --image $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE_NAME:$GITHUB_SHA \
+            --region $REGION \
+            --platform managed \
+            --quiet \
+            --allow-unauthenticated \
+            --set-env-vars GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}
+

--- a/README.md
+++ b/README.md
@@ -249,3 +249,19 @@ spec:
 - **イメージレジストリ**: us-west1-docker.pkg.dev/dx-card-game/dx-card-game/app:latest
 - **サービス名**: dx-card-game
 - **URL**: https://dx-card-game-537832106570.us-west1.run.app
+
+## GitHub Actionsによる自動デプロイ
+
+このリポジトリには、`main` ブランチへのプッシュをトリガーとして Cloud Run へデプロイする GitHub Actions ワークフロー `.github/workflows/deploy.yml` が含まれています。
+
+### 必要なシークレット設定
+GitHub の **Settings > Secrets and variables > Actions** で以下を登録してください。
+
+- `GCP_PROJECT_ID` – 使用する Google Cloud プロジェクト ID
+- `GCP_REGION` – デプロイ先リージョン (例: `us-west1`)
+- `GAR_REPOSITORY` – Artifact Registry のリポジトリ名 (例: `dx-card-game/dx-card-game`)
+- `GCP_SA_KEY` – Cloud Run と Cloud Build の権限を持つサービスアカウントの JSON キー
+- `GEMINI_API_KEY` – アプリが利用する Gemini API キー
+
+### 実行内容
+ワークフローでは Docker イメージをビルドして Artifact Registry にプッシュし、そのイメージを用いて Cloud Run サービス `dx-card-game` を更新します。


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build & deploy to Cloud Run
- document GitHub Actions deployment and required secrets in README

## Testing
- `npm run build` *(fails: next not found)*